### PR TITLE
Simplified tests

### DIFF
--- a/character/character.go
+++ b/character/character.go
@@ -2,9 +2,9 @@ package character
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"strings"
+	"sync/atomic"
 
 	"github.com/brittonhayes/rpg/stat"
 )
@@ -14,8 +14,9 @@ var (
 )
 
 var (
+	defaultID    uint64
 	defaultName  = "Character 1"
-	defaultRank  = Rank(0)
+	defaultRank  = uint64(1)
 	defaultStats = map[string]*Stat{
 		stat.Stamina: NewStat(stat.Full),
 	}
@@ -25,11 +26,10 @@ var (
 	}
 )
 
-type Rank int
-
 type Character struct {
+	ID        uint64
 	Name      string
-	Rank      Rank
+	Rank      uint64
 	Health    float64
 	Armor     float64
 	Stats     map[string]*Stat
@@ -44,6 +44,7 @@ type Option func(*Character)
 func New(options ...Option) *Character {
 
 	p := &Character{
+		ID:        atomic.AddUint64(&defaultID, 1),
 		Name:      defaultName,
 		Health:    100.00,
 		Armor:     0.00,
@@ -105,7 +106,7 @@ func WithArmor(armor float64) Option {
 
 func WithRank(rank int) Option {
 	return func(character *Character) {
-		character.Rank = Rank(rank)
+		character.Rank = uint64(rank)
 	}
 }
 
@@ -127,10 +128,6 @@ func (c *Character) Stat(name string) *Stat {
 	return &Stat{value: 0.00}
 }
 
-func (r Rank) String() string {
-	return fmt.Sprintf("Rank: %d", r)
-}
-
 func (c *Character) IsCalled() string {
 	return c.Name
 }
@@ -139,10 +136,10 @@ func (c *Character) IsPlayable() bool {
 	return c.Playable
 }
 
-func (c *Character) RankTo(rank int) {
-	c.Rank = Rank(rank)
+func (c *Character) RankTo(rank uint64) {
+	c.Rank = rank
 }
 
-func (c *Character) RankUp(rank int) {
-	c.Rank += Rank(rank)
+func (c *Character) RankUp(rank uint64) {
+	c.Rank += rank
 }

--- a/character/character_test.go
+++ b/character/character_test.go
@@ -7,390 +7,133 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNew(t *testing.T) {
-	type args struct {
-		options []Option
-	}
-	tests := []struct {
-		name string
-		args args
-		want *Character
-	}{
-		{
-			name: "test new default character",
-			args: args{
-				options: nil,
-			},
-			want: &Character{
-				Name:      defaultName,
-				Health:    100.00,
-				Armor:     0.00,
-				Rank:      defaultRank,
-				Stats:     defaultStats,
-				Attacks:   defaultAttacks,
-				Abilities: nil,
-				Inventory: nil,
-				Playable:  false,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, New(tt.args.options...))
-		})
-	}
+func TestCharacter(t *testing.T) {
+	t.Run("Test new character", func(t *testing.T) {
+		expect := &Character{
+			ID:        1,
+			Name:      defaultName,
+			Health:    100.00,
+			Armor:     0.00,
+			Rank:      defaultRank,
+			Stats:     defaultStats,
+			Attacks:   defaultAttacks,
+			Abilities: nil,
+			Inventory: nil,
+			Playable:  false,
+		}
+
+		assert.Equal(t, expect, New())
+	})
+
+	t.Run("Test character stat", func(t *testing.T) {
+		arg := "CHARM"
+		field := map[string]*Stat{"CHARM": {value: 99.00}}
+		expect := &Stat{
+			value: 99.00,
+		}
+
+		c := &Character{Stats: field}
+		assert.Equal(t, expect, c.Stat(arg))
+	})
+
+	t.Run("Test character is player", func(t *testing.T) {
+		arg := false
+		expect := false
+
+		c := &Character{Playable: arg}
+		assert.Equal(t, expect, c.IsPlayable())
+	})
 }
 
-func TestIsPlayer(t *testing.T) {
-	tests := []struct {
-		name      string
-		character *Character
-		want      bool
-	}{
-		{
-			name:      "Test is player",
-			character: &Character{Playable: false},
-			want:      true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := New(IsPlayer())
-			assert.Equal(t, tt.want, c.Playable)
-		})
-	}
+func TestWithOption(t *testing.T) {
+	t.Run("Test character with name", func(t *testing.T) {
+		arg := "Mario"
+		expect := "Mario"
+
+		c := New(WithName(arg))
+		assert.Equal(t, expect, c.Name)
+	})
+
+	t.Run("Test with rank", func(t *testing.T) {
+		arg := 2
+		expect := uint64(2)
+
+		c := New(WithRank(arg))
+		assert.Equal(t, expect, c.Rank)
+	})
+
+	t.Run("Test with health", func(t *testing.T) {
+		arg := 20.00
+		expect := 20.00
+
+		c := New(WithHealth(arg))
+		assert.Equal(t, expect, c.Health)
+	})
+
+	t.Run("Test with armor", func(t *testing.T) {
+		arg := 20.00
+		expect := 20.00
+
+		c := New(WithArmor(arg))
+		assert.Equal(t, expect, c.Armor)
+	})
+
+	t.Run("Test with stamina", func(t *testing.T) {
+		arg := 20.00
+		expect := 20.00
+
+		c := New(WithStamina(arg))
+		assert.Equal(t, expect, c.Stats[stat.Stamina].value)
+	})
+
+	t.Run("Test with attacks", func(t *testing.T) {
+		args := map[string]*Attack{
+			"light": defaultAttacks.Light,
+			"heavy": defaultAttacks.Heavy,
+		}
+
+		expect := map[string]*Attack{
+			"light": defaultAttacks.Light,
+			"heavy": defaultAttacks.Heavy,
+		}
+
+		c := New(WithAttacks(args["light"], args["heavy"]))
+		assert.Equal(t, expect["light"], c.Attacks.Light)
+		assert.Equal(t, expect["heavy"], c.Attacks.Heavy)
+	})
+
+	t.Run("Test with custom stats", func(t *testing.T) {
+		arg := defaultStats
+		expect := defaultStats
+
+		c := New(WithCustomStats(arg))
+		assert.Equal(t, expect, c.Stats)
+	})
 }
 
-func TestWithAttacks(t *testing.T) {
-	type args struct {
-		light *Attack
-		heavy *Attack
-	}
+func TestRank(t *testing.T) {
+	t.Run("Test rank to", func(t *testing.T) {
+		arg := uint64(10)
+		expect := uint64(10)
 
-	type want struct {
-		light *Attack
-		heavy *Attack
-	}
+		c := &Character{
+			Rank: uint64(25),
+		}
 
-	tests := []struct {
-		name string
-		args args
-		want want
-	}{
-		{
-			name: "Test with default attacks",
-			args: args{
-				light: defaultAttacks.Light,
-				heavy: defaultAttacks.Heavy,
-			},
-			want: want{
-				light: defaultAttacks.Light,
-				heavy: defaultAttacks.Heavy,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := New(WithAttacks(tt.args.light, tt.args.heavy))
-			assert.Equal(t, tt.want.light, c.Attacks.Light)
-			assert.Equal(t, tt.want.heavy, c.Attacks.Heavy)
-		})
-	}
-}
+		c.RankTo(arg)
+		assert.Equal(t, expect, c.Rank)
+	})
 
-func TestWithName(t *testing.T) {
-	type args struct {
-		name string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{name: "Test character with name", args: args{name: "Mario"}, want: "Mario"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := New(WithName(tt.args.name))
-			assert.Equal(t, tt.want, c.Name)
-		})
-	}
-}
+	t.Run("Test rank up", func(t *testing.T) {
+		base := uint64(1)
+		arg := uint64(10)
+		expect := uint64(11)
 
-func TestWithStamina(t *testing.T) {
-	type args struct {
-		stamina float64
-	}
-	tests := []struct {
-		name string
-		args args
-		want float64
-	}{
-		{
-			name: "Test with stamina",
-			args: args{
-				stamina: float64(20.00),
-			},
-			want: float64(20.00),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := New(WithStamina(tt.args.stamina))
-			assert.Equal(t, tt.args.stamina, c.Stats[stat.Stamina].value)
-		})
-	}
-}
+		c := &Character{
+			Rank: base,
+		}
 
-func TestWithHealth(t *testing.T) {
-	tests := []struct {
-		name   string
-		health float64
-		want   float64
-	}{
-		{name: "Test with health", health: 20.00, want: 20.00},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := New(WithHealth(tt.health))
-			assert.Equal(t, tt.want, c.Health)
-		})
-	}
-}
-
-func TestWithArmor(t *testing.T) {
-	tests := []struct {
-		name  string
-		armor float64
-		want  float64
-	}{
-		{name: "Test with armor", armor: 20.00, want: 20.00},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := New(WithArmor(tt.armor))
-			assert.Equal(t, tt.want, c.Armor)
-		})
-	}
-}
-
-func TestWithRank(t *testing.T) {
-	type args struct {
-		rank int
-	}
-	tests := []struct {
-		name string
-		args args
-		want Rank
-	}{
-		{name: "Test with rank", args: args{rank: 2}, want: Rank(2)},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := New(WithRank(tt.args.rank))
-			assert.Equal(t, tt.want, c.Rank)
-		})
-	}
-}
-
-func TestWithCustomStats(t *testing.T) {
-	type args struct {
-		stats map[string]*Stat
-	}
-	tests := []struct {
-		name string
-		args args
-		want map[string]*Stat
-	}{
-		{name: "Test with custom stats", args: args{stats: defaultStats}, want: defaultStats},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := New(WithCustomStats(tt.args.stats))
-			assert.Equal(t, tt.want, c.Stats)
-		})
-	}
-}
-
-func TestCharacter_Stat(t *testing.T) {
-	type fields struct {
-		Name      string
-		Rank      Rank
-		Stats     map[string]*Stat
-		Attacks   Attacks
-		Abilities []Ability
-		Inventory []Item
-		Playable  bool
-	}
-	type args struct {
-		name string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   *Stat
-	}{
-		{
-			name: "Test character stat",
-			fields: fields{
-				Name: defaultName,
-				Rank: defaultRank,
-				Stats: map[string]*Stat{
-					"CHARM": {
-						value: 100.00,
-					},
-				},
-				Attacks:   defaultAttacks,
-				Abilities: nil,
-				Inventory: nil,
-				Playable:  true,
-			},
-			args: args{
-				name: "CHARM",
-			},
-			want: &Stat{
-				value: 100.00,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &Character{
-				Name:      tt.fields.Name,
-				Rank:      tt.fields.Rank,
-				Stats:     tt.fields.Stats,
-				Attacks:   tt.fields.Attacks,
-				Abilities: tt.fields.Abilities,
-				Inventory: tt.fields.Inventory,
-				Playable:  tt.fields.Playable,
-			}
-			assert.Equal(t, tt.want, c.Stat(tt.args.name))
-		})
-	}
-}
-
-func TestCharacter_Health(t *testing.T) {
-	tests := []struct {
-		name   string
-		health float64
-		want   float64
-	}{
-		{
-			name:   "Test character health",
-			health: 100.00,
-			want:   100.00,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &Character{
-				Health: tt.health,
-			}
-			assert.Equal(t, tt.want, c.Health)
-		})
-	}
-}
-
-func TestRank_String(t *testing.T) {
-	tests := []struct {
-		name string
-		r    Rank
-		want string
-	}{
-		{name: "Test rank string", r: Rank(1), want: "Rank: 1"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.r.String())
-		})
-	}
-}
-
-func TestCharacter_RankTo(t *testing.T) {
-	type fields struct {
-		Name      string
-		Rank      Rank
-		Stats     map[string]*Stat
-		Attacks   Attacks
-		Abilities []Ability
-		Inventory []Item
-		Playable  bool
-	}
-	type args struct {
-		rank int
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   Rank
-	}{
-		{
-			name: "Test rank to",
-			fields: fields{
-				Rank: Rank(1),
-			},
-			args: args{
-				rank: 20,
-			},
-			want: Rank(20),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &Character{
-				Rank: tt.fields.Rank,
-			}
-			c.RankTo(tt.args.rank)
-			assert.Equal(t, tt.want, c.Rank)
-		})
-	}
-}
-
-func TestCharacter_RankUp(t *testing.T) {
-	type fields struct {
-		Name      string
-		Rank      Rank
-		Stats     map[string]*Stat
-		Attacks   Attacks
-		Abilities []Ability
-		Inventory []Item
-		Playable  bool
-	}
-	type args struct {
-		rank int
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   Rank
-	}{
-		{
-			name: "Test rank up",
-			fields: fields{
-				Rank: Rank(1),
-			},
-			args: args{
-				rank: 3,
-			},
-			want: Rank(4),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &Character{
-				Name:      tt.fields.Name,
-				Rank:      tt.fields.Rank,
-				Stats:     tt.fields.Stats,
-				Attacks:   tt.fields.Attacks,
-				Abilities: tt.fields.Abilities,
-				Inventory: tt.fields.Inventory,
-				Playable:  tt.fields.Playable,
-			}
-			c.RankUp(tt.args.rank)
-			assert.Equal(t, tt.want, c.Rank)
-		})
-	}
+		c.RankUp(arg)
+		assert.Equal(t, expect, c.Rank)
+	})
 }

--- a/character/combat_test.go
+++ b/character/combat_test.go
@@ -32,22 +32,14 @@ func TestNewAttack(t *testing.T) {
 	}
 }
 
-func TestCharacter_IsDead(t *testing.T) {
+func Test(t *testing.T) {
 	tests := []struct {
 		name   string
 		health float64
 		want   bool
 	}{
-		{
-			name:   "Test character is dead",
-			health: 0.00,
-			want:   true,
-		},
-		{
-			name:   "Test character is not dead",
-			health: 100.00,
-			want:   false,
-		},
+		{name: "Test character is dead", health: 0.00, want: true},
+		{name: "Test character is not dead", health: 100.00, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -60,35 +52,38 @@ func TestCharacter_IsDead(t *testing.T) {
 }
 
 func TestCharacter_Attack(t *testing.T) {
-	type args struct {
-		target *Character
-		attack *Attack
-	}
 	tests := []struct {
 		name   string
-		args   args
+		target *Character
+		attack *Attack
 		want   float64
 	}{
 		{
-			name: "Test character attack",
-			args: args{
-				target: &Character{
-					Health: 100.00,
-				},
-				attack: &Attack{
-					Name:   "Test attack",
-					Kind:   LightAttack,
-					Damage: 10.00,
-				},
+			name:   "Test character light attack",
+			target: &Character{Health: 100.00},
+			attack: &Attack{
+				Name:   "Light attack",
+				Kind:   LightAttack,
+				Damage: 10.00,
 			},
 			want: 90.00,
+		},
+		{
+			name:   "Test character heavy attack",
+			target: &Character{Health: 100.00},
+			attack: &Attack{
+				Name:   "Heavy attack",
+				Kind:   HeavyAttack,
+				Damage: 40.00,
+			},
+			want: 60.00,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Character{}
-			c.Attack(tt.args.target, tt.args.attack)
-			assert.Equal(t, tt.want, tt.args.target.Health)
+			c.Attack(tt.target, tt.attack)
+			assert.Equal(t, tt.want, tt.target.Health)
 		})
 	}
 }

--- a/character/stat_test.go
+++ b/character/stat_test.go
@@ -6,117 +6,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewStat(t *testing.T) {
-	type args struct {
-		value float64
-	}
-	tests := []struct {
-		name string
-		args args
-		want *Stat
-	}{
-		{name: "Test new stat", args: args{value: 100.00}, want: &Stat{value: 100.00}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, NewStat(tt.args.value))
-		})
-	}
+func TestStat(t *testing.T) {
+	t.Run("new stat", func(t *testing.T) {
+		arg := 100.00
+		want := &Stat{value: 100.00}
+
+		assert.Equal(t, want, NewStat(arg))
+	})
+
+	t.Run("to string", func(t *testing.T) {
+		field := &Stat{value: 100.00}
+                expect := "100"
+
+		assert.Equal(t, expect, field.String())
+	})
+
+	t.Run("up", func(t *testing.T) {
+		field := &Stat{value: 80.00}
+		arg := 10.00
+		expect := 90.00
+
+		field.Up(arg)
+		assert.Equal(t, expect, field.value)
+	})
+
+	t.Run("down", func(t *testing.T) {
+		field := &Stat{value: 80.00}
+		arg := 10.00
+		expect := 70.00
+
+		field.Down(arg)
+		assert.Equal(t, expect, field.value)
+	})
+
+	t.Run("to value", func(t *testing.T) {
+		field := &Stat{value: 80.00}
+		arg := 10.00
+		expect := 10.00
+
+		field.To(arg)
+		assert.Equal(t, expect, field.value)
+	})
 }
 
-func TestStat_String(t *testing.T) {
-	type fields struct {
-		value float64
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{name: "Test stat to string", fields: fields{value: 100.00}, want: "100"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Stat{
-				value: tt.fields.value,
-			}
-			assert.Equal(t, tt.want, s.String())
-		})
-	}
-}
-
-func TestStat_Up(t *testing.T) {
-	type fields struct {
-		value float64
-	}
-	type args struct {
-		value float64
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Stat{
-				value: tt.fields.value,
-			}
-			s.Up(tt.args.value)
-		})
-	}
-}
-
-func TestStat_To(t *testing.T) {
-	type fields struct {
-		value float64
-	}
-	type args struct {
-		value float64
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   float64
-	}{
-		{name: "Test stat to", fields: fields{value: 30.00}, args: args{value: 50.00}, want: 50.00},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Stat{
-				value: tt.fields.value,
-			}
-			s.To(tt.args.value)
-			assert.Equal(t, tt.want, s.value)
-		})
-	}
-}
-
-func TestStat_Down(t *testing.T) {
-	type fields struct {
-		value float64
-	}
-	type args struct {
-		value float64
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   float64
-	}{
-		{name: "Test stat down", fields: fields{value: 20.00}, args: args{value: 10.00}, want: 10.00},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Stat{
-				value: tt.fields.value,
-			}
-			s.Down(tt.args.value)
-			assert.Equal(t, tt.want, s.value)
-		})
-	}
-}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -2,103 +2,55 @@ package logger
 
 import (
 	"bytes"
-	"io"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewLogger(t *testing.T) {
-	tests := []struct {
-		name       string
-		want       *Logger
-		wantWriter string
-	}{
-		{name: "testing logger", want: &Logger{Writer: &bytes.Buffer{}}, wantWriter: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			writer := &bytes.Buffer{}
-			assert.Equal(t, tt.want, NewLogger(writer))
-			assert.Equal(t, tt.wantWriter, writer.String())
-		})
-	}
+func prefix(level string) string {
+	return fmt.Sprintf("%-8s", strings.ToUpper(level))
 }
 
-func TestLogger_Attack(t *testing.T) {
-	type fields struct {
-		Writer io.Writer
-	}
-	type args struct {
-		attacker string
-		target   string
-		attack   string
-		damage   float64
-	}
-	tests := []struct {
-		name      string
-		fields    fields
-		args      args
-		assertion assert.ErrorAssertionFunc
-	}{
-		{
-			name: "Test attack log",
-			fields: fields{
-				Writer: &bytes.Buffer{},
-			},
-			args: args{
-				attacker: "Mario",
-				target:   "Bowser",
-				attack:   "Stomp",
-				damage:   float64(10.00),
-			},
-			assertion: assert.NoError,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			l := &Logger{
-				Writer: tt.fields.Writer,
-			}
-			tt.assertion(t, l.Attack(tt.args.attacker, tt.args.target, tt.args.attack, tt.args.damage))
-		})
-	}
-}
+func TestLogger(t *testing.T) {
+	t.Run("new logger", func(t *testing.T) {
+		arg := &bytes.Buffer{}
+		expect := &Logger{Writer: &bytes.Buffer{}}
 
-func TestLogger_Status(t *testing.T) {
-	type fields struct {
-		Writer io.Writer
-	}
-	type args struct {
-		character string
-		health    float64
-		armor     float64
-	}
-	tests := []struct {
-		name      string
-		fields    fields
-		args      args
-		assertion assert.ErrorAssertionFunc
-	}{
-		{
-			name: "",
-			fields: fields{
-				Writer: &bytes.Buffer{},
-			},
-			args: args{
-				character: "Mario",
-				health:    100.00,
-				armor:     100.00,
-			},
-			assertion: assert.NoError,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			l := &Logger{
-				Writer: tt.fields.Writer,
-			}
-			tt.assertion(t, l.Status(tt.args.character, tt.args.health, tt.args.armor))
-		})
-	}
+		assert.Equal(t, expect, NewLogger(arg))
+	})
+
+	t.Run("logger log info", func(t *testing.T) {
+		arg := "Hello"
+		field := &bytes.Buffer{}
+		expect := fmt.Sprintln(prefix("INFO"), arg)
+
+		l := NewLogger(field)
+		l.Log(LevelInfo, arg)
+		assert.Equal(t, expect, field.String())
+	})
+
+	t.Run("logger attack", func(t *testing.T) {
+		argAttacker := "Mario"
+		argTarget := "Bowser"
+		argAttack := "Stomp"
+		argDamage := 100.00
+
+		field := &bytes.Buffer{}
+
+		l := &Logger{Writer: field}
+		assert.NoError(t, l.Attack(argAttacker, argTarget, argAttack, argDamage))
+	})
+
+	t.Run("logger attack", func(t *testing.T) {
+		argCharacter := "Mario"
+		argHealth := 100.00
+		argArmor := 100.00
+
+		field := &bytes.Buffer{}
+
+		l := &Logger{Writer: field}
+		assert.NoError(t, l.Status(argCharacter, argHealth, argArmor))
+	})
 }


### PR DESCRIPTION
# Changes

- Made tests much easier to read
- Switched to t.Run() rather than table tests
- Removed rank type in favor of uint to enforce positive numbers
- Assigned an atomic uint64 ID to characters to prepare for use of concurrency

All tests now follow the format:

```go
	// This improved readability greatly and removes quite a bit of boilerplate.
	t.Run("test name", func(t *testing.T) {
		arg := foo
		field := bar
		expect := baz

		c := &ExampleStruct{ExampleField: field}
		assert.Equal(t, expect, c.ExampleMethod(arg))
	})
```